### PR TITLE
Stop private notes from being cleared when turn ends

### DIFF
--- a/src/main/java/net/deckserver/dwr/model/GameModel.java
+++ b/src/main/java/net/deckserver/dwr/model/GameModel.java
@@ -178,6 +178,7 @@ public class GameModel implements Comparable<GameModel> {
         for (String key : (new ArrayList<>(views.keySet()))) {
             GameView view = views.get(key);
             view.globalChanged();
+            view.privateNotesChanged();
         }
     }
 

--- a/src/main/webapp/WEB-INF/jsps/help/layout.jsp
+++ b/src/main/webapp/WEB-INF/jsps/help/layout.jsp
@@ -56,7 +56,7 @@
         instance.setContent("Loading...");
         let ref = $(instance.reference);
         let cardId = ref.data('card-id');
-        let content = '<img width="350" height="500" src="https://static.deckserver.net/images/' + cardId + '" alt="Loading..."/>';
+        let content = '<img width="350" height="500" src="https://static.tornsignpost.org/images/' + cardId + '" alt="Loading..."/>';
         instance.setContent(content);
       }
     });

--- a/src/main/webapp/js/card-modal.js
+++ b/src/main/webapp/js/card-modal.js
@@ -33,7 +33,7 @@ function showPlayCardModal(event) {
     if (cardId) {
         $.get({
             dataType: "json",
-            url: "https://static.deckserver.net/json/" + cardId, success: function (card) {
+            url: "https://static.tornsignpost.org/json/" + cardId, success: function (card) {
                 playCardModal.data('hand-coord', coordinates);
                 playCardModal.data('region', region);
                 playCardModal.data('do-not-replace', region === "research" ? true : card.doNotReplace);
@@ -238,7 +238,7 @@ function showCardModal(event) {
     if (cardId) {
         $.get({
             dataType: "json",
-            url: "https://static.deckserver.net/json/" + cardId, success: function (card) {
+            url: "https://static.tornsignpost.org/json/" + cardId, success: function (card) {
                 var modal = $('#cardModal');
                 modal.data('controller', controller);
                 modal.data('region', region);

--- a/src/main/webapp/js/ds.js
+++ b/src/main/webapp/js/ds.js
@@ -1196,12 +1196,12 @@ function addCardTooltips(parent) {
                     instance.reference.removeAttribute('title');
                 }
                 if (profile.imageTooltipPreference) {
-                    let content = `<img width="350" height="500" src="https://static.deckserver.net/images/${cardId}" alt="Loading..."/>`;
+                    let content = `<img width="350" height="500" src="https://static.tornsignpost.org/images/${cardId}" alt="Loading..."/>`;
                     instance.setContent(content);
                 } else {
                     $.get({
                         dataType: "html",
-                        url: "https://static.deckserver.net/html/" + cardId, success: function (data) {
+                        url: "https://static.tornsignpost.org/html/" + cardId, success: function (data) {
                             let content = `<div class="p-2">${data}</div>`;
                             instance.setContent(content);
                         }


### PR DESCRIPTION
Make sure private notes are flagged as needing to be redrawn when turn ends