### PR TITLE
#181: added a "x" Close Button to the Card Modal

### DIFF
--- a/src/main/webapp/WEB-INF/jsps/game/card-modal.jsp
+++ b/src/main/webapp/WEB-INF/jsps/game/card-modal.jsp
@@ -23,6 +23,7 @@
                     <select id="sect-select" class="form-select form-select-sm ms-2 card-sect-select d-none"
                             style="width:auto"></select>
                     <span class="card-cost"></span>
+                    <button class="btn-close" title="Close" onclick="closeModal();">&times;</button>
                 </span>
             </div>
             <div class="modal-body">

--- a/src/main/webapp/js/card-modal.js
+++ b/src/main/webapp/js/card-modal.js
@@ -714,6 +714,10 @@ function movePrey() {
     return false;
 }
 
+function closeModal() {
+    $('#cardModal').modal('hide');
+}
+
 function removeCounter(doCommand = true) {
     var modal = $('#cardModal');
     var counters = modal.data('counters');


### PR DESCRIPTION
feature #181: On small mobile devices its very hard to close the card modal because the only way to close it is to click outside of the card modal. On smaller mobile phones there is hardly any space to tap away the card modal. Added a "x" Close button in the upper right corner for an easy way to close the card modal.