### PR TITLE
#185: show command adds null instead of empty string

### DIFF
--- a/src/main/java/net/deckserver/dwr/model/JolGame.java
+++ b/src/main/java/net/deckserver/dwr/model/JolGame.java
@@ -623,7 +623,7 @@ public record JolGame(String id, GameData data) {
         String notes = builder.toString();
         for (String recipient : recipients) {
             PlayerData recipientData = data.getPlayer(recipient);
-            String privateNotes = recipientData.getNotes();
+            String privateNotes = recipientData.getNotes() == null ? "" : recipientData.getNotes();
             privateNotes += notes;
             recipientData.setNotes(privateNotes);
         }


### PR DESCRIPTION
bug #185: The show command eg show lib adds a null string to the notes in case the private notes of the player have been empty. Added a check that will return an empty string instead of null in case that the player notes are empty. 